### PR TITLE
Use saturating cast to uint32 for timestamp

### DIFF
--- a/test/AllocationModule.test.ts
+++ b/test/AllocationModule.test.ts
@@ -22,6 +22,7 @@ import {
 import { Operation } from "../src/ts/lib/safe";
 
 import { customError, RevertMessage } from "./lib/custom-errors";
+import { createSnapshot, restoreSnapshot } from "./lib/hardhat";
 import { setTime, setTimeAndMineBlock } from "./lib/time";
 
 const VCOW_ABI = [
@@ -408,6 +409,20 @@ describe("AllocationModule", () => {
             )
               .to.emit(allocationModule, "ClaimRedeemed")
               .withArgs(claimant.address, testedAmount);
+          });
+
+          it("can be redeemed if current timestamp does not fit a uint32", async function () {
+            // This test sets the network time to a very large value. We restore the snapshot to undo these changes.
+            const snapshot = await createSnapshot(hre);
+            await requiredMockForSwapping(amount);
+            await requiredMockForTransferring(amount);
+            await setTime(2 ** 32);
+            await expect(
+              allocationModule
+                .connect(claimant)
+                [claimFunction](...claimInputFromAmount(amount)),
+            ).not.to.be.reverted;
+            await restoreSnapshot(hre, snapshot);
           });
         });
       });

--- a/test/lib/hardhat.ts
+++ b/test/lib/hardhat.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export async function createSnapshot(
+  hre: HardhatRuntimeEnvironment,
+): Promise<unknown> {
+  return await hre.network.provider.request({
+    method: "evm_snapshot",
+    params: [],
+  });
+}
+export async function restoreSnapshot(
+  hre: HardhatRuntimeEnvironment,
+  snapshot: unknown,
+) {
+  await hre.network.provider.request({
+    method: "evm_revert",
+    params: [snapshot],
+  });
+}

--- a/test/mainnet/lib/chain-fork.ts
+++ b/test/mainnet/lib/chain-fork.ts
@@ -1,5 +1,7 @@
 import { HardhatRuntimeEnvironment, HttpNetworkConfig } from "hardhat/types";
 
+import { createSnapshot, restoreSnapshot } from "../../lib/hardhat";
+
 // https://hardhat.org/hardhat-network/guides/mainnet-forking.html
 
 // Keep a snapshot of the state of the blockchain immediately after the fork.
@@ -24,10 +26,7 @@ export async function forkMainnet(hre: HardhatRuntimeEnvironment) {
       },
     ],
   });
-  snapshotFreshFork = await hre.network.provider.request({
-    method: "evm_snapshot",
-    params: [],
-  });
+  snapshotFreshFork = await createSnapshot(hre);
 }
 
 export async function stopMainnetFork(hre: HardhatRuntimeEnvironment) {
@@ -38,8 +37,5 @@ export async function stopMainnetFork(hre: HardhatRuntimeEnvironment) {
 }
 
 export async function resetMainnetFork(hre: HardhatRuntimeEnvironment) {
-  await hre.network.provider.request({
-    method: "evm_revert",
-    params: [snapshotFreshFork],
-  });
+  await restoreSnapshot(hre, snapshotFreshFork);
 }


### PR DESCRIPTION
Addresses a comment in @nlordell's review of the contract.

As all claims must have an end date that fits an `uint32`, this change makes all vesting position claimable at any point in time in the future.

### Test Plan

New unit test.