### PR TITLE
Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gnosis.pm/cow-token",
+  "name": "@cowprotocol/team-cow-allocation-module",
   "version": "1.0.0",
   "license": "LGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
A leftover from when the repository was created: I used the token project as a template.

### Test Plan

No test.