### PR TITLE
Add view function returning claimable amount

### DIFF
--- a/src/contracts/AllocationModule.sol
+++ b/src/contracts/AllocationModule.sol
@@ -148,6 +148,23 @@ contract AllocationModule {
         );
     }
 
+    /// @dev Returns how many COW tokens are claimable at the current point in time by the given address. Tokens that
+    /// were already claimed by the user are not included in the output amount.
+    /// @param beneficiary The address that owns the claim.
+    /// @return The amount of COW that could be claimed by the beneficiary at this point in time.
+    function claimableCow(address beneficiary) external view returns (uint256) {
+        if (allocation[beneficiary].totalAmount == 0) {
+            return 0;
+        }
+        (uint96 alreadyClaimedAmount, uint96 fullVestedAmount) = retrieveClaimedAmounts(
+            beneficiary,
+            // solhint-disable-next-line not-rely-on-time
+            block.timestamp
+        );
+
+        return fullVestedAmount - alreadyClaimedAmount;
+    }
+
     /// @dev Computes and sends the entire amount of COW that have been vested so far to the beneficiary.
     /// @param beneficiary The address that redeems its claim.
     /// @param timestampAtClaimingTime The timestamp at claiming time.


### PR DESCRIPTION
There is currently no straightforward way to get the amount that can be claimed by an address at the current point in time.
This might be a desired feature if for example we want to let employees vote using their vested but unclaimed amounts. Currently, this is possible but requires to add custom logic when computing voting shares.

This PR adds the new view function.

More context [here](https://cowservices.slack.com/archives/C0361CDEMK9/p1652862928464129).

### Test Plan

New unit tests.