### PR TITLE
Do not revert if swapping vCOW to COW reverts

### DIFF
--- a/src/contracts/test/MockVCow.sol
+++ b/src/contracts/test/MockVCow.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+/// @dev Mock of vCOW token. Emits an event when calling `swap`.
+/// @title vCOW mock contract
+/// @author CoW Protocol Developers
+contract MockVcow {
+    address public cowToken;
+
+    constructor(address _cowToken) {
+        cowToken = _cowToken;
+    }
+
+    event Swapped(address caller, uint256 amount);
+
+    function swap(uint256 amount) external {
+        emit Swapped(msg.sender, amount);
+    }
+}

--- a/test/AllocationModule.test.ts
+++ b/test/AllocationModule.test.ts
@@ -249,7 +249,7 @@ describe("AllocationModule", () => {
           ).not.to.be.reverted;
         });
 
-        it("sends out COW even if if swapping vCOW to COW reverts at vCOW level", async function () {
+        it("sends out COW even if swapping vCOW to COW reverts at vCOW level", async function () {
           // Transfer mock is missing. We verify it's used by checking that not setting the mock makes the transaction
           // revert.
           await controller.contract.mock.execTransactionFromModule

--- a/test/AllocationModule.test.ts
+++ b/test/AllocationModule.test.ts
@@ -259,13 +259,13 @@ describe("AllocationModule", () => {
               vcowIface.encodeFunctionData("swap", [amount.div(2)]),
               Operation.Call,
             )
-            .reverts();
+            .returns(false);
           await setTime(claimStart + duration / 2);
           await expect(
             allocationModule
               .connect(claimant)
               [claimFunction](...claimInputFromAmount(amount.div(2))),
-          ).to.be.revertedWith(RevertMessage.MockRevert);
+          ).to.be.revertedWith(RevertMessage.UninitializedMock);
         });
 
         it("reverts if swapping vCOW to COW reverts at the controller level", async function () {

--- a/test/AllocationModule.test.ts
+++ b/test/AllocationModule.test.ts
@@ -231,40 +231,59 @@ describe("AllocationModule", () => {
           ({ start: claimStart } = await requiredNewAllocation());
         });
 
-        describe("reverts if swapping vCOW to COW reverts", function () {
-          it("at vCOW level", async function () {
-            await controller.contract.mock.execTransactionFromModule
-              .withArgs(
-                vcow.address,
-                0,
-                vcowIface.encodeFunctionData("swap", [amount.div(2)]),
-                Operation.Call,
-              )
-              .returns(false);
-            await setTime(claimStart + duration / 2);
-            await expect(
-              allocationModule
-                .connect(claimant)
-                [claimFunction](...claimInputFromAmount(amount.div(2))),
-            ).to.be.revertedWith(customError("RevertedVcowSwap"));
-          });
+        it("does not revert if swapping vCOW to COW reverts at vCOW level", async function () {
+          await controller.contract.mock.execTransactionFromModule
+            .withArgs(
+              vcow.address,
+              0,
+              vcowIface.encodeFunctionData("swap", [amount.div(2)]),
+              Operation.Call,
+            )
+            .returns(false);
+          await requiredMockForTransferring(amount.div(2));
+          await setTime(claimStart + duration / 2);
+          await expect(
+            allocationModule
+              .connect(claimant)
+              [claimFunction](...claimInputFromAmount(amount.div(2))),
+          ).not.to.be.reverted;
+        });
 
-          it("at the controller level", async function () {
-            await controller.contract.mock.execTransactionFromModule
-              .withArgs(
-                vcow.address,
-                0,
-                vcowIface.encodeFunctionData("swap", [amount.div(2)]),
-                Operation.Call,
-              )
-              .reverts();
-            await setTime(claimStart + duration / 2);
-            await expect(
-              allocationModule
-                .connect(claimant)
-                [claimFunction](...claimInputFromAmount(amount.div(2))),
-            ).to.be.revertedWith(RevertMessage.MockRevert);
-          });
+        it("sends out COW even if if swapping vCOW to COW reverts at vCOW level", async function () {
+          // Transfer mock is missing. We verify it's used by checking that not setting the mock makes the transaction
+          // revert.
+          await controller.contract.mock.execTransactionFromModule
+            .withArgs(
+              vcow.address,
+              0,
+              vcowIface.encodeFunctionData("swap", [amount.div(2)]),
+              Operation.Call,
+            )
+            .reverts();
+          await setTime(claimStart + duration / 2);
+          await expect(
+            allocationModule
+              .connect(claimant)
+              [claimFunction](...claimInputFromAmount(amount.div(2))),
+          ).to.be.revertedWith(RevertMessage.MockRevert);
+        });
+
+        it("reverts if swapping vCOW to COW reverts at the controller level", async function () {
+          await controller.contract.mock.execTransactionFromModule
+            .withArgs(
+              vcow.address,
+              0,
+              vcowIface.encodeFunctionData("swap", [amount.div(2)]),
+              Operation.Call,
+            )
+            .reverts();
+          await requiredMockForTransferring(amount.div(2));
+          await setTime(claimStart + duration / 2);
+          await expect(
+            allocationModule
+              .connect(claimant)
+              [claimFunction](...claimInputFromAmount(amount.div(2))),
+          ).to.be.revertedWith(RevertMessage.MockRevert);
         });
 
         describe("reverts if transferring COW reverts", function () {


### PR DESCRIPTION
We internally discussed the issue of letting users claim using COW rather than requiring a swap from vCOW first, and it was determined to be admissible.

For reference, [here](https://cowservices.slack.com/archives/C0361CDEMK9/p1653920901296529) is the internal discussion.

This PR implements the changes needed to accept a failing `swap()` from vCOW to COW.

### Test Plan

Modified unit tests.