### PR TITLE
Use duration instead of claim end in storage

### DIFF
--- a/src/contracts/AllocationModule.sol
+++ b/src/contracts/AllocationModule.sol
@@ -19,7 +19,7 @@ contract AllocationModule {
         uint96 claimedAmount;
         /// @dev Timestamp when this vesting position started.
         uint32 start;
-        /// @dev How long after vesting start must be waited before claiming the total amount.
+        /// @dev Timespan between vesting start and end.
         uint32 duration;
     }
 

--- a/src/ts/claim.ts
+++ b/src/ts/claim.ts
@@ -7,7 +7,7 @@ export interface VestingPosition {
   totalAmount: BigNumberish;
   claimedAmount: BigNumberish;
   start: number;
-  end: number;
+  duration: number;
 }
 
 export interface AddClaimInput {

--- a/test/AllocationModule.test.ts
+++ b/test/AllocationModule.test.ts
@@ -126,7 +126,7 @@ describe("AllocationModule", () => {
       expect(vestingPosition.totalAmount).to.equal(amount);
       expect(vestingPosition.claimedAmount).to.equal(constants.Zero);
       expect(vestingPosition.start).to.equal(start);
-      expect(vestingPosition.end).to.equal(start + duration);
+      expect(vestingPosition.duration).to.equal(duration);
     });
 
     it("emits event", async function () {


### PR DESCRIPTION
Addresses two comments from the audit, namely:
- by storing `duration` instead of `end` you can save a little bit of calculation
- it's probably better to convert `start` and `end` to `uint256` than to convert `block.timestamp` to `uint32` [here]( https://github.com/cowprotocol/team-cow-allocation/blob/63f03106615352e9fb52abe6e52f159552d6ca60/src/contracts/AllocationModule.sol#L217)

The end result is simpler code and a small gas cost improvement (~100 gas/call).
Saturating to `uint32` is not needed anymore as we don't need to cast to `uint32`.

A small difference from the current code is that now we can create valid claims that expire after the timestamp represented by the max value for a `uint32` (the longest claim is one starting at `uint32(-1)` with duration `uint32(-1)`, which would expire in the year 2242).

### Test Plan

Existing unit tests. Note that we already test that `claimCow [...] can be redeemed if current timestamp does not fit a uint32`.