### PR TITLE
Update deployment procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ It will be associated with the mainnet team controller address automatically.
 
 This contract is designed to be a module for a Gnosis Safe, and before using it it needs to be activated in the controller safe.
 Running the command above will print to screen instructions on how to enable the module.
+
+## Verify deployed contract on Etherscan
+
+After obtaining an Etherscan API key, run:
+
+```sh
+export ETHERSCAN_API_KEY=your key here
+yarn verify:etherscan --network mainnet
+```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "hardhat test",
     "test:ignored-in-coverage": "MOCHA_CONF='ignored in coverage' hardhat test",
     "test:mainnet": "MOCHA_CONF='mainnet' hardhat test",
-    "test:no-mainnet": "MOCHA_CONF='no mainnet' hardhat test"
+    "test:no-mainnet": "MOCHA_CONF='no mainnet' hardhat test",
+    "verify:etherscan": "hardhat etherscan-verify --license LGPL-3.0 --force-license"
   },
   "main": "lib/commonjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
Changes required to make the deployment work smoothly.

Namely:
- network file generation now works, even if no `networks.json` file exists already.
- documented how to verify contract on Etherscan. 

### Test Plan

Check out branch `deployment` from #67, delete `networks.json` and run `yarn deploy --network mainnet` (without exporting any private key: no contract will be deployed since it's already deployed).
